### PR TITLE
Add ASCII decode error handling from the COM port

### DIFF
--- a/python/comporthandler.py
+++ b/python/comporthandler.py
@@ -98,6 +98,9 @@ class ComPortHandler:
 
             except SyntaxError:
                 data = "Unable to understand data from serial port, check baud configuration."
+            
+            except UnicodeDecodeError:
+                self.known_arduinos[port]["log"].log("WARNING: Decoding problem detected. The USB connection might be suspect.")
 
             if data:
                 self.known_arduinos[port]["timer"] = time.time()


### PR DESCRIPTION
The experimenters are experiencing ASCII decode errors when they first plug in the Arduino.  Instead of sussing out COM port instantiation delays, this will just log the fact that there was an error and keep on carrying on.